### PR TITLE
feat: add car-park parking metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,34 @@ docker run -e PORT=9090 -p 9090:9090 ghcr.io/menzerath/aachen-mobility-exporter:
 ```bash
 $ curl http://localhost:9090/metrics
 
-# HELP aachen_mobility_parking_free How many parking spots are free.
-# TYPE aachen_mobility_parking_free gauge
-aachen_mobility_parking_free{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 0
-aachen_mobility_parking_free{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 11
-aachen_mobility_parking_free{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 13
+# HELP aachen_mobility_parking_carpark_free How many car-park parking spots are free.
+# TYPE aachen_mobility_parking_carpark_free gauge
+aachen_mobility_parking_carpark_free{description="APAG Parkhaus",id="865",latitude="6.045195",longitude="50.774804",name="Uniklinik",trend="up"} 1744
 ...
 
-# HELP aachen_mobility_parking_occupied How many parking spots are occupied.
-# TYPE aachen_mobility_parking_occupied gauge
-aachen_mobility_parking_occupied{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 1
-aachen_mobility_parking_occupied{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 97.31
-aachen_mobility_parking_occupied{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 149.57
+# HELP aachen_mobility_parking_carpark_load Percentage of how many car-park parking spots are taken.
+# TYPE aachen_mobility_parking_carpark_load gauge
+aachen_mobility_parking_carpark_load{description="APAG Parkhaus",id="865",latitude="6.045195",longitude="50.774804",name="Uniklinik",trend="up"} 14.55
 ...
 
-# HELP aachen_mobility_parking_total How many parking spots are available in total.
-# TYPE aachen_mobility_parking_total gauge
-aachen_mobility_parking_total{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 1
-aachen_mobility_parking_total{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 108.31
-aachen_mobility_parking_total{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 162.57
+# HELP aachen_mobility_parking_roadside_free How many roadside parking spots are free.
+# TYPE aachen_mobility_parking_roadside_free gauge
+aachen_mobility_parking_roadside_free{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 0
+aachen_mobility_parking_roadside_free{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 11
+aachen_mobility_parking_roadside_free{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 13
+...
+
+# HELP aachen_mobility_parking_roadside_occupied How many roadside parking spots are occupied.
+# TYPE aachen_mobility_parking_roadside_occupied gauge
+aachen_mobility_parking_roadside_occupied{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 1
+aachen_mobility_parking_roadside_occupied{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 97.31
+aachen_mobility_parking_roadside_occupied{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 149.57
+...
+
+# HELP aachen_mobility_parking_roadside_total How many roadside parking spots are available in total.
+# TYPE aachen_mobility_parking_roadside_total gauge
+aachen_mobility_parking_roadside_total{latitude="50.770016",location_id="233",longitude="6.099145",name="Friedrichstraße 111-117",parent_locations="1",sub_locations="0",type="PARKING_AREA"} 1
+aachen_mobility_parking_roadside_total{latitude="50.772200",location_id="364",longitude="6.098808",name="Friedrichstraße Süd",parent_locations="1",sub_locations="4",type="GROUP"} 108.31
+aachen_mobility_parking_roadside_total{latitude="50.772953",location_id="366",longitude="6.098711",name="Friedrichstraße",parent_locations="0",sub_locations="2",type="GROUP"} 162.57
 ...
 ```

--- a/client/car_park_parking.go
+++ b/client/car_park_parking.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const carParkParkingURL = "https://verkehr-mp.aachen.de/FROST-Server/v1.1/Things?%24filter=Datastreams%2Fproperties%2Ftype%20eq%20%27Parkobjekt%27&%24expand=Locations%2CDatastreams%2FObservations(%24top%3D1%3B%24orderby%3DphenomenonTime%20desc)&%24count=true"
+
+// CarParkParking describes the current car-park-parking situation at a specific location.
+type CarParkParking struct {
+	Count int64 `json:"@iot.count"`
+	Value []struct {
+		ID          int64  `json:"@iot.id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+
+		Locations []struct {
+			Location struct {
+				Geometry struct {
+					Type        string    `json:"type"`
+					Coordinates []float64 `json:"coordinates"`
+				} `json:"geometry"`
+			} `json:"location"`
+		} `json:"Locations"`
+
+		Datastreams []struct {
+			Observations []struct {
+				Timestamp  string `json:"resultTime"`
+				Result     string `json:"result"`
+				Parameters struct {
+					Load  float64 `json:"load"`
+					Trend string  `json:"trend"`
+				} `json:"parameters"`
+			} `json:"Observations"`
+		} `json:"Datastreams"`
+	} `json:"value"`
+}
+
+// GetCarParkParkingData returns the current car-park-parking situation from the public api.
+func GetCarParkParkingData() (CarParkParking, error) {
+	response, err := http.Get(carParkParkingURL)
+	if err != nil {
+		return CarParkParking{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		message, err := io.ReadAll(response.Body)
+		if err != nil {
+			return CarParkParking{}, fmt.Errorf("http error %d", response.StatusCode)
+		}
+		return CarParkParking{}, fmt.Errorf("http error %d: %s", response.StatusCode, message)
+	}
+
+	var data CarParkParking
+	if err = json.NewDecoder(response.Body).Decode(&data); err != nil {
+		return data, err
+	}
+	return data, nil
+}

--- a/client/car_park_parking_test.go
+++ b/client/car_park_parking_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCarParkParkingData(t *testing.T) {
+	data, err := GetCarParkParkingData()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+}

--- a/client/roadside_parking.go
+++ b/client/roadside_parking.go
@@ -22,19 +22,16 @@ type RoadsideParking struct {
 	SubLocations    []string `json:"SubLocations"`
 	ParentLocations []string `json:"ParentLocations"`
 
-	Positions RoadsideParkingPosition `json:"Positions"`
-}
-
-// RoadsideParkingPosition contains two locations of a roadside-parking position.
-type RoadsideParkingPosition struct {
-	Center     RoadsideParkingPositionCoordinates `json:"Center"`
-	Navigation RoadsideParkingPositionCoordinates `json:"Navigation"`
-}
-
-// RoadsideParkingPositionCoordinates contains the coordinates of a roadside-parking position.
-type RoadsideParkingPositionCoordinates struct {
-	Lat  float64 `json:"Lat"`
-	Long float64 `json:"Long"`
+	Positions struct {
+		Center struct {
+			Lat  float64 `json:"Lat"`
+			Long float64 `json:"Long"`
+		} `json:"Center"`
+		Navigation struct {
+			Lat  float64 `json:"Lat"`
+			Long float64 `json:"Long"`
+		} `json:"Navigation"`
+	}
 }
 
 // GetRoadsideParkingData returns the current roadside-parking situation from the public api.

--- a/client/roadside_parking.go
+++ b/client/roadside_parking.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 )
 
-const parkingURL = "https://verkehr.aachen.de/api/sonah/api/v2/locations"
+const roadsideParkingURL = "https://verkehr.aachen.de/api/sonah/api/v2/locations"
 
-// Parking describes the current parking situation at a specific location.
-type Parking struct {
+// RoadsideParking describes the current roadside-parking situation at a specific location.
+type RoadsideParking struct {
 	LocationID int64  `json:"LocationID"`
 	Name       string `json:"Name"`
 	Type       string `json:"Type"`
@@ -22,24 +22,24 @@ type Parking struct {
 	SubLocations    []string `json:"SubLocations"`
 	ParentLocations []string `json:"ParentLocations"`
 
-	Positions ParkingPosition `json:"Positions"`
+	Positions RoadsideParkingPosition `json:"Positions"`
 }
 
-// ParkingPosition contains two locations of a parking position.
-type ParkingPosition struct {
-	Center     ParkingPositionCoordinates `json:"Center"`
-	Navigation ParkingPositionCoordinates `json:"Navigation"`
+// RoadsideParkingPosition contains two locations of a roadside-parking position.
+type RoadsideParkingPosition struct {
+	Center     RoadsideParkingPositionCoordinates `json:"Center"`
+	Navigation RoadsideParkingPositionCoordinates `json:"Navigation"`
 }
 
-// ParkingPositionCoordinates contains the coordinates of a parking position.
-type ParkingPositionCoordinates struct {
+// RoadsideParkingPositionCoordinates contains the coordinates of a roadside-parking position.
+type RoadsideParkingPositionCoordinates struct {
 	Lat  float64 `json:"Lat"`
 	Long float64 `json:"Long"`
 }
 
-// GetParkingData returns the current parking situation from the public api.
-func GetParkingData() ([]Parking, error) {
-	response, err := http.Get(parkingURL)
+// GetRoadsideParkingData returns the current roadside-parking situation from the public api.
+func GetRoadsideParkingData() ([]RoadsideParking, error) {
+	response, err := http.Get(roadsideParkingURL)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func GetParkingData() ([]Parking, error) {
 		return nil, fmt.Errorf("http error %d: %s", response.StatusCode, message)
 	}
 
-	var data []Parking
+	var data []RoadsideParking
 	if err = json.NewDecoder(response.Body).Decode(&data); err != nil {
 		return data, err
 	}

--- a/client/roadside_parking_test.go
+++ b/client/roadside_parking_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetParkingData(t *testing.T) {
+func TestGetRoadsideParkingData(t *testing.T) {
 	data, err := GetRoadsideParkingData()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)

--- a/client/roadside_parking_test.go
+++ b/client/roadside_parking_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGetParkingData(t *testing.T) {
-	data, err := GetParkingData()
+	data, err := GetRoadsideParkingData()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, data)
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -51,9 +51,9 @@ func (e *Exporter) Describe(c chan<- *prometheus.Desc) {
 
 // Collect collects and exposes all metric values.
 func (e *Exporter) Collect(c chan<- prometheus.Metric) {
-	parkingData, err := client.GetParkingData()
+	parkingData, err := client.GetRoadsideParkingData()
 	if err != nil {
-		e.logger.Error("fetching parking data failed", zap.Error(err))
+		e.logger.Error("fetching roadside-parking data failed", zap.Error(err))
 		for _, desc := range e.descriptions {
 			c <- prometheus.NewInvalidMetric(desc, err)
 		}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -40,7 +40,7 @@ func NewExporter() *Exporter {
 			),
 			prometheus.NewDesc(
 				"aachen_mobility_parking_carpark_load",
-				"Percentage describing how many car-park parking spots are taken.",
+				"Percentage of how many car-park parking spots are taken.",
 				[]string{"id", "name", "description", "trend", "latitude", "longitude"},
 				nil,
 			),
@@ -136,7 +136,7 @@ func (e *Exporter) Collect(c chan<- prometheus.Metric) {
 
 		free, err := strconv.ParseFloat(parking.Datastreams[0].Observations[0].Result, 64)
 		if err != nil {
-			e.logger.Error("parsing car-park-parking free failed", zap.Error(err))
+			e.logger.Warn("parsing car-park-parking free failed", zap.Error(err))
 		}
 		c <- prometheus.MustNewConstMetric(
 			e.descriptions[4],


### PR DESCRIPTION
```
# HELP aachen_mobility_parking_carpark_free How many car-park parking spots are free.
# TYPE aachen_mobility_parking_carpark_free gauge
aachen_mobility_parking_carpark_free{description="APAG Parkhaus",id="865",latitude="6.045195",longitude="50.774804",name="Uniklinik",trend="up"} 1744

# HELP aachen_mobility_parking_carpark_load Percentage of how many car-park parking spots are taken.
# TYPE aachen_mobility_parking_carpark_load gauge
aachen_mobility_parking_carpark_load{description="APAG Parkhaus",id="865",latitude="6.045195",longitude="50.774804",name="Uniklinik",trend="up"} 14.55
```